### PR TITLE
arch/intel_x64/vcpu.h: add Header Guard

### DIFF
--- a/bfvmm/include/vcpu/vcpu.h
+++ b/bfvmm/include/vcpu/vcpu.h
@@ -260,7 +260,7 @@ public:
     /// Add Run Delegate
     ///
     /// Adds a run delegate to the VCPU. The delegates are added to a queue and
-    /// executed in FILO order. All delegates are executed unless an exception
+    /// executed in FIFO order. All delegates are executed unless an exception
     /// is thrown that is not handled.
     ///
     /// @expects none
@@ -269,12 +269,12 @@ public:
     /// @param d the delegate to add to the vcpu
     ///
     VIRTUAL void add_run_delegate(run_delegate_t &&d) noexcept
-    { m_run_delegates.push_back(std::move(d)); }
+    { m_run_delegates.push_front(std::move(d)); }
 
     /// Add Halt Delegate
     ///
     /// Adds a halt delegate to the VCPU. The delegates are added to a queue and
-    /// executed in FILO order. All delegates are executed unless an exception
+    /// executed in FIFO order. All delegates are executed unless an exception
     /// is thrown that is not handled.
     ///
     /// @expects none
@@ -283,12 +283,12 @@ public:
     /// @param d the delegate to add to the vcpu
     ///
     VIRTUAL void add_hlt_delegate(hlt_delegate_t &&d) noexcept
-    { m_hlt_delegates.push_back(std::move(d)); }
+    { m_hlt_delegates.push_front(std::move(d)); }
 
     /// Add Init Delegate
     ///
     /// Adds a init delegate to the VCPU. The delegates are added to a queue and
-    /// executed in FILO order. All delegates are executed unless an exception
+    /// executed in FIFO order. All delegates are executed unless an exception
     /// is thrown that is not handled.
     ///
     /// @expects none
@@ -297,12 +297,12 @@ public:
     /// @param d the delegate to add to the vcpu
     ///
     VIRTUAL void add_init_delegate(init_delegate_t &&d) noexcept
-    { m_init_delegates.push_back(std::move(d)); }
+    { m_init_delegates.push_front(std::move(d)); }
 
     /// Add Fini Delegate
     ///
     /// Adds a fini delegate to the VCPU. The delegates are added to a queue and
-    /// executed in FILO order. All delegates are executed unless an exception
+    /// executed in FIFO order. All delegates are executed unless an exception
     /// is thrown that is not handled.
     ///
     /// @expects none
@@ -311,7 +311,7 @@ public:
     /// @param d the delegate to add to the vcpu
     ///
     VIRTUAL void add_fini_delegate(fini_delegate_t &&d) noexcept
-    { m_fini_delegates.push_back(std::move(d)); }
+    { m_fini_delegates.push_front(std::move(d)); }
 
 private:
 


### PR DESCRIPTION
add header guard to prevent contents of this header from including twice
